### PR TITLE
Fix Atom feed links

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -1,8 +1,8 @@
 xml.instruct!
 xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
-  site_url = "http://blog.url.com/"
-  xml.title "Blog Name"
-  xml.subtitle "Blog subtitle"
+  site_url = "http://blog.jwilm.io/"
+  xml.title "Joe Wilm"
+  xml.subtitle "blog.jwilm.io"
   xml.id URI.join(site_url, blog.options.prefix.to_s)
   xml.link "href" => URI.join(site_url, blog.options.prefix.to_s)
   xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
@@ -16,7 +16,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.id URI.join(site_url, article.url)
       xml.published article.date.to_time.iso8601
       xml.updated File.mtime(article.source_file).iso8601
-      xml.author { xml.name "Article Author" }
+      xml.author { xml.name "Joe Wilm" }
       # xml.summary article.summary, "type" => "html"
       xml.content article.body, "type" => "html"
     end


### PR DESCRIPTION
The URLs in http://blog.jwilm.io/feed.xml point an example domain. I'm not familiar with Ruby, nor sure this is the correct branch, but hopefully this will fix it?

Normally I would just e-mail you, but I stumbled across this when trying to find your e-mail address, and, well, here we are. Thanks for the interesting blog!